### PR TITLE
Fix range issue when printing partner aged balance

### DIFF
--- a/account_standard_report/wizard/account_standard_report.py
+++ b/account_standard_report/wizard/account_standard_report.py
@@ -600,7 +600,7 @@ class AccountStandardLedger(models.TransientModel):
         date_range AS
             (
                 SELECT
-                    %s AS date_current,
+                    DATE %s AS date_current,
                     DATE %s - INTEGER '30' AS date_less_30_days,
                     DATE %s - INTEGER '60' AS date_less_60_days,
                     DATE %s - INTEGER '90' AS date_less_90_days,
@@ -633,12 +633,12 @@ class AccountStandardLedger(models.TransientModel):
                 WHEN %s = 'partner' THEN COALESCE(init.balance, 0) + (SUM(aml.balance) OVER (PARTITION BY aml.partner_id ORDER BY aml.partner_id, aml.date, aml.id))
                 ELSE SUM(aml.balance) OVER (PARTITION BY aml.journal_id ORDER BY aml.journal_id, aml.date, aml.id)
             END AS cumul_balance,
-            CASE WHEN aml.date_maturity > date_range.date_less_30_days THEN aml.balance END AS current,
-            CASE WHEN aml.date_maturity > date_range.date_less_60_days AND aml.date_maturity <= date_range.date_less_30_days THEN aml.balance END AS age_30_days,
-            CASE WHEN aml.date_maturity > date_range.date_less_90_days AND aml.date_maturity <= date_range.date_less_60_days THEN aml.balance END AS age_60_days,
-            CASE WHEN aml.date_maturity > date_range.date_less_120_days AND aml.date_maturity <= date_range.date_less_90_days THEN aml.balance END AS age_90_days,
-            CASE WHEN aml.date_maturity > date_range.date_older AND aml.date_maturity <= date_range.date_less_120_days THEN aml.balance END AS age_120_days,
-            CASE WHEN aml.date_maturity <= date_range.date_older THEN aml.balance END AS older,
+            CASE WHEN aml.date_maturity > date_range.date_current THEN aml.balance END AS current,
+            CASE WHEN aml.date_maturity > date_range.date_less_30_days AND aml.date_maturity <= date_range.date_current THEN aml.balance END AS age_30_days,
+            CASE WHEN aml.date_maturity > date_range.date_less_60_days AND aml.date_maturity <= date_range.date_less_30_days THEN aml.balance END AS age_60_days,
+            CASE WHEN aml.date_maturity > date_range.date_less_90_days AND aml.date_maturity <= date_range.date_less_60_days THEN aml.balance END AS age_90_days,
+            CASE WHEN aml.date_maturity > date_range.date_less_120_days AND aml.date_maturity <= date_range.date_less_90_days THEN aml.balance END AS age_120_days,
+            CASE WHEN aml.date_maturity <= date_range.date_less_120_days THEN aml.balance END AS older,
             %s AS company_currency_id,
             aml.amount_currency AS amount_currency,
             aml.currency_id AS currency_id


### PR DESCRIPTION
This PR fix a bug when generating aged partner balanced. The value under "current", "0-30days",... are not correct compared to standard Odoo aged balanced. Here is an example:
My standard Odoo aged balanced (for confidentiality reason, i don't display the details):
![image](https://user-images.githubusercontent.com/7678583/43149053-df5abb52-8f66-11e8-8b88-c2dbd46fcf10.png)

 And compare it to the extract in Excel from standard report without modifications from this PR:
![image](https://user-images.githubusercontent.com/7678583/43149330-7b819d66-8f67-11e8-8aa1-0006f7ae6288.png)


You can see that the value are not coherent. They should be in other column. 
Not due should be 0, 
0-30 should be 24077,48 
30-60 should be 24825,82

Here is the result with this fix:
![image](https://user-images.githubusercontent.com/7678583/43149181-25cf3694-8f67-11e8-87d4-77ae3f96a9ba.png)
